### PR TITLE
exclude org.slf4j slf4j-api

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     "io.gatling" % "gatling-test-framework" % gatlingVersion % "provided",
   )
 
-  lazy val hikari = "com.zaxxer"     % "HikariCP" % "5.0.1" exclude("org.slf4j", "slf4j-api")
+  lazy val hikari = "com.zaxxer"     % "HikariCP" % "5.0.1" exclude ("org.slf4j", "slf4j-api")
   lazy val h2jdbc = "com.h2database" % "h2"       % "2.1.214" % Test
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     "io.gatling" % "gatling-test-framework" % gatlingVersion % "provided",
   )
 
-  lazy val hikari = "com.zaxxer"     % "HikariCP" % "5.0.1"
+  lazy val hikari = "com.zaxxer"     % "HikariCP" % "5.0.1" exclude("org.slf4j", "slf4j-api")
   lazy val h2jdbc = "com.h2database" % "h2"       % "2.1.214" % Test
 
 }


### PR DESCRIPTION
Exclude org.slf4j slf4j-api from com.zaxxer.HikariCP for using vector and gatling 3.8